### PR TITLE
feat(ci): Add CI support to build a debug APK on every push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,59 @@
+name: Android CI
+
+on:
+  push:
+    tags:
+
+jobs:
+
+  build:
+    name: Build MBCompass
+    runs-on: ubuntu-latest
+    steps:
+
+      # Checkout Code
+      - uses: actions/checkout@v1
+
+      # Setup JDK 17
+      - name: Setup JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+
+      # Set Gradle Home
+      - name: Set Gradle Home
+        run: export GRADLE_USER_HOME=~/.gradle
+
+      # Gradle Cache
+      - name: Gradle Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle
+          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-cache-
+
+      # Build Release APK
+      - name: Build Release APK
+        run: bash ./gradlew assembleDebug --stacktrace
+
+      # Generate APK Names
+      - name: Generate APK Names
+        id: generate_apk_names
+        run: |
+          SHORT_SHA="$(git rev-parse --short ${{ github.sha }})"
+          VERSION_NAME="$(./gradlew --quiet --console=plain printVersionName)"  
+          VERSION_NAME="${VERSION_NAME// /-}"
+          echo ::set-output name=NAME_DEBUG::"mbcompass-v${VERSION_NAME}-${SHORT_SHA}-debug.apk"
+
+      # Rename APKs
+      - name: Rename APKs
+        run: |
+          mkdir -p app/apks/
+          mv app/build/outputs/apk/debug/app-debug.apk "app/apks/${{ steps.generate_apk_names.outputs.NAME_DEBUG }}"
+
+      # Upload Prod APK
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.generate_apk_names.outputs.NAME_DEBUG }}
+          path: "app/apks/${{ steps.generate_apk_names.outputs.NAME_DEBUG }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,14 +32,15 @@ jobs:
           key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-cache-
 
-      # Build Release APK
-      - name: Build Release APK
+      # Build Debug APK
+      - name: Build Debug APK
         run: bash ./gradlew assembleDebug --stacktrace
 
       # Generate APK Names
       - name: Generate APK Names
         id: generate_apk_names
         run: |
+          chmod a+x ./gradlew
           SHORT_SHA="$(git rev-parse --short ${{ github.sha }})"
           VERSION_NAME="$(./gradlew --quiet --console=plain printVersionName)"  
           VERSION_NAME="${VERSION_NAME// /-}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## 🧭MBCompass - Compose Compass App
+## 🧭MBCompass - Compose Compass App [![Android CI](https://github.com/MubarakNative/MBCompass/actions/workflows/ci.yaml/badge.svg)](https://github.com/MubarakNative/MBCompass/actions/workflows/ci.yaml)
 
 ![Banner MBCompass](BannerMBCompass.png)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,3 +71,9 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }
+
+task("printVersionName"){
+    doLast {
+        println(android.defaultConfig.versionName)
+    }
+}


### PR DESCRIPTION
As discussed on Mastodon, in this PR you will find the implementation for the automatic Android CI on every push to the repo. It will generate a `debug` apk. You will find the APKs under each run https://github.com/MubarakNative/MBCompass/actions after the PR is merged. A CI badge is also added to the header of the README file for better visibility. 