### PR TITLE
build: update lib and set minSdk version to 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ## About
 
-**MBCompass** is a modern, free, and open-source compass and navigation app without **ads**, **IAP**, or **tracking**. Built with **Jetpack Compose**, it supports compass and navigation features while being **lightweight** and simple.
+**MBCompass** is a modern, free, and open-source compass and navigation app without **ads**, **IAP**, or **tracking**. Built with Jetpack Compose, it supports compass and navigation features while being **lightweight** and simple.
 
 > Not just a compass. Not a map app.
 >

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId = "com.mubarak.mbcompass"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 36
         versionCode = 13
         versionName = "1.1.12"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,23 +2,23 @@
 
 [versions]
 agp = "8.13.1"
-datastorePreferences = "1.1.7"
+datastorePreferences = "1.2.0"
 fragmentKtx = "1.8.9"
 hiltAndroid = "2.56.2"
 kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
-hiltNavigationCompose = "1.2.0"
+hiltNavigationCompose = "1.3.0"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-lifecycleRuntimeKtx = "2.9.4"
-activityCompose = "1.11.0"
+lifecycleRuntimeKtx = "2.10.0"
+activityCompose = "1.12.2"
 composeBom = "2025.09.00"
 navigationCompose = "2.9.6"
 kspVersion = "2.2.0-2.0.2"
 kotlinxSerializationJson = "1.9.0"
 osmdroidAndroid = "6.1.20"
-uiViewbinding = "1.9.5"
+uiViewbinding = "1.10.0"
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityCompose" }


### PR DESCRIPTION
- Updated minSdk version to ```23``` (Android 6) from 21 (Android 5), due to new changes in the androidx libraries themselves.
> [Source](https://developer.android.com/jetpack/androidx/versions#version-table): Starting in June 2025, new releases of many AndroidX libraries previously targeting minSdk 21 will be updated to require minSdk 23.